### PR TITLE
Use email as account name in Vault TOTP; allow setting issuer name in env

### DIFF
--- a/app/controllers/security_controller.rb
+++ b/app/controllers/security_controller.rb
@@ -7,7 +7,7 @@ class SecurityController < ApplicationController
 
   # GET /security
   def enable
-    @otp = Vault::TOTP.safe_create(current_account.uid)
+    @otp = Vault::TOTP.safe_create(current_account.uid, current_account.email)
 
     if @otp.nil?
       redirect_to(index_path, alert: 'You already have created your OTP key')

--- a/lib/vault/totp.rb
+++ b/lib/vault/totp.rb
@@ -9,9 +9,9 @@ module Vault
       ISSUER_NAME = 'Barong'
 
       # Make sure the key won't be regenerated
-      def safe_create(uid)
+      def safe_create(uid, email)
         return if exist?(uid)
-        create(uid)
+        create(uid, email)
       end
 
       # Check if OTP key already exists for given uid
@@ -25,12 +25,12 @@ module Vault
 
     private
 
-      def create(uid)
+      def create(uid, email)
         Vault.logical.write(
           "totp/keys/#{uid}",
           generate: true,
-          issuer: ISSUER_NAME,
-          account_name: uid,
+          issuer: ENV.fetch('APP_NAME', 'Barong'),
+          account_name: email,
           qr_size: 300
         )
       end


### PR DESCRIPTION
- Pass email along with uid to vault
- Get issuer from ENV
Closes #258 