### PR TITLE
Implemented API JWT renewal

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -7,6 +7,7 @@ module API
 
       mount API::V1::Accounts
       mount API::V1::Profiles
+      mount API::V1::Security
 
       add_swagger_documentation base_path: '/api',
                                 info: {

--- a/app/controllers/api/v1/security.rb
+++ b/app/controllers/api/v1/security.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'doorkeeper/grape/helpers'
+require 'barong/security/access_token'
+
+module API
+  module V1
+    class Security < Grape::API
+      helpers Doorkeeper::Grape::Helpers
+
+      before do
+        doorkeeper_authorize!
+
+        def current_account_id
+          doorkeeper_token.resource_owner_id
+        end
+
+        def current_application
+          doorkeeper_token.application
+        end
+      end
+
+      desc 'Security related routes'
+      resource :security do
+        desc 'Renews JWT if current JWT is valid'
+        post '/renew' do
+          # expiration time will be specified by the request param or taken from ENV, if both are nil, it will be 4 hours
+          Barong::Security::AccessToken.create params[:expires_in], current_account_id, current_application
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -25,7 +25,7 @@ Doorkeeper.configure do
 
   # Access token expiration time (default 2 hours).
   # If you want to disable expiration, set this to nil.
-  # access_token_expires_in 2.hours
+  access_token_expires_in ENV.fetch('JWT_LIFETIME', 4.hours)
 
   # Assign a custom TTL for implicit grants.
   # custom_access_token_expires_in do |oauth_client|
@@ -119,10 +119,9 @@ Doorkeeper::JWT.configure do
   # about the account.
   token_payload do |opts|
     account = Account.find(opts[:resource_owner_id])
-
     {
       iat: Time.now.to_i,
-      exp: 4.hours.from_now.to_i,
+      exp: opts[:expires_in].to_i.seconds.from_now.to_i,
       sub: 'session',
       iss: 'barong',
       aud: opts[:scopes].all,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,11 @@
+ # Barong API
+
+ Bagong API includes these routes:
+ - 1. get '/api/account' - returns current account info(uid email level role state)
+ - 2. post '/api/security/renew' - returns new JWT if old one is valid, otherwise,
+ returns {"error":"The access token is invalid"} or {"error":"The access token expired"},
+ if access token has been expired
+
+Expiration of new JWT can also be specified by parameter 'expires_in' in seconds, otherwise,
+it will look for the ENV variable JWT_LIFETIME, if both are not specified, JWT expiration
+time will be set to 4 hours

--- a/lib/barong/security/access_token.rb
+++ b/lib/barong/security/access_token.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Barong
+  module Security
+    # Helpers for JWT
+    module AccessToken
+      class <<self
+        def create(expires_in, acc_id, application)
+          # Doorkeeper method, which creates the JWT for the current user with scope 'peatio' and expiration time specified earlier
+          # Don't be confused by 'find' in method's name,
+          # according to source code it returns old token if access_tokens are reusable(can be specified in config)
+          return unless acc_id
+          Doorkeeper::AccessToken.find_or_create_for(
+            application,
+            acc_id,
+            Doorkeeper.configuration.scopes.to_s,
+            expires_in || Doorkeeper.configuration.access_token_expires_in,
+            false
+          ).token
+        end
+      end
+    end
+  end
+end

--- a/spec/api/security_spec.rb
+++ b/spec/api/security_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'JWT renewal test' do
+  describe 'POST /api/security/renew' do
+    subject!(:access_token) { create :doorkeeper_token }
+    let(:headers) do
+      { Authorization: "Bearer #{access_token.token}" }
+    end
+
+    it 'Checks if current JWT is valid and returns new valid JWT' do
+      post '/api/security/renew', headers: headers
+      expect(response.status).to eq(201)
+
+      post '/api/security/renew',
+           headers: { Authorization: "Bearer #{JSON.parse(response.body)}" }
+      expect(response.status).to eq(201)
+    end
+
+    it 'Checks if current JWT is valid and returns JWT with specified liftime' do
+      post '/api/security/renew', params: { expires_in: 1000 }, headers: headers
+      expect(response.status).to eq(201)
+      new_jwt_payload = JWT.decode JSON.parse(response.body), nil, false
+      expect(new_jwt_payload.first['exp'].to_i).to be <= Time.now.to_i + 1000
+    end
+
+    it 'Checks if current JWT is valid and returns error, cause it is not' do
+      post '/api/security/renew'
+      expect(response.body).to eq("{\"error\":\"The access token is invalid\"}")
+    end
+
+    it 'Checks if current JWT is valid and returns error, cause it has expired' do
+      post '/api/security/renew', params: { expires_in: 1 }, headers: headers
+      expect(response.status).to eq(201)
+      new_jwt = JSON.parse(response.body)
+      sleep(2)
+      post '/api/security/renew', headers: { 'Authorization' => "Bearer #{new_jwt}"}
+      expect(response.body).to eq("{\"error\":\"The access token expired\"}")
+    end
+  end
+end

--- a/spec/factories/doorkeeper_application.rb
+++ b/spec/factories/doorkeeper_application.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :doorkeeper_application, class: Doorkeeper::Application do
+    name { Faker::RickAndMorty.character }
+    redirect_uri { 'https://' + Faker::Internet.url }
+  end
+end

--- a/spec/factories/doorkeeper_token.rb
+++ b/spec/factories/doorkeeper_token.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :doorkeeper_token, class: Doorkeeper::AccessToken do
+    application_id { FactoryBot.create(:doorkeeper_application).id }
+    resource_owner_id { FactoryBot.create(:account).id }
+    scopes :peatio
+  end
+end


### PR DESCRIPTION
  + Fixed expiring time in Doorkeeper-JWT
  + Add ability to specify jwt lifetime by ENV['JWT_LIFETIME']
  + Add allow_simple_login feature
  + Updated docs


