### PR TITLE
Fixed admin user creation in db:seed

### DIFF
--- a/config/seed.yml
+++ b/config/seed.yml
@@ -2,7 +2,7 @@ admin:
   email:    admin@barong.io
 applications:
   - name:         "Local Peatio"
-    redirect_uri: "http://localhost:8000/auth/barong/callback"
+    redirect_uri: "http://peatio:8000/auth/barong/callback"
     uid:          "a68be319fca51caca60eed5711226e568bd1c1d13ff452b945515f1a6ffbaca4"
     secret:       "ab80e2c843861c4d23e63f5472cd1c9ee6f55e388863e21f22b03a9093977f29"
     skipauth:     true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,8 +10,8 @@ if Account.find_by(email: seed['admin']['email']).nil?
   )
 
   # Confirm admin account
-  admin.update(confirmed_at: Time.now)
-  admin.level_set(:mail)
+  admin.confirm
+  admin.level_set(:identity)
 
   puts "Admin email: #{admin.email}"
   puts "Admin password: #{admin.password}"


### PR DESCRIPTION
Set admin account state to 'active'
Set admin level to 3
Updated seed.yml to work in workbench(we were getting 'invalid redirect url')