### PR TITLE
Add ability to configure lockable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ cache:
   - bundler
   - yarn
 
-branches:
-  only:
-    - "master"
-
 env:
   - RAILS_ENV=test
     RAKE_ENV=test

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -177,27 +177,30 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  config.lock_strategy = :failed_attempts
 
-  # Defines which key will be used when locking and unlocking an account
-  config.unlock_keys = [:email]
+  if ENV.fetch('ENABLE_LOCKABLE', 'true') == 'true'
+    config.lock_strategy = :failed_attempts
+    # Defines which key will be used when locking and unlocking an account
+    config.unlock_keys = [:email]
 
-  # Defines which strategy will be used to unlock an account.
-  # :email = Sends an unlock link to the user email
-  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
-  # :both  = Enables both strategies
-  # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :both
+    # Defines which strategy will be used to unlock an account.
+    # :email = Sends an unlock link to the user email
+    # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+    # :both  = Enables both strategies
+    # :none  = No unlock strategy. You should handle unlocking by yourself.
+    config.unlock_strategy = ENV.fetch('UNLOCK_STRATEGY', 'both').to_sym
 
-  # Number of authentication tries before locking an account if lock_strategy
-  # is failed attempts.
-  config.maximum_attempts = 5
+    # Number of authentication tries before locking an account if lock_strategy
+    # is failed attempts.
+    config.maximum_attempts = ENV.fetch('MAXIMUM_ATTEMPTS', '5').to_i
 
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  config.unlock_in = 1.hour
+    # Time interval to unlock the account if :time is enabled as unlock_strategy.
+    config.unlock_in = ENV.fetch('UNLOCK_INTERVAL', '3600').to_i.seconds
 
-  # Warn on the last attempt before the account is locked.
-  config.last_attempt_warning = false
+    # Warn on the last attempt before the account is locked.
+    last_attempt_warning = ENV.fetch('LAST_ATTEMPT_WARNING', 'true') == 'true'
+    config.last_attempt_warning = last_attempt_warning
+  end
 
   # ==> Configuration for :recoverable
   #


### PR DESCRIPTION
Added next ENV variables

`ENABLE_LOCKABLE: ['true', 'false']`
`UNLOCK_STRATEGY: 'both' by default`
 Defines which strategy will be used to unlock an account.
  * 'email' = Sends an unlock link to the user email
  * 'time'  = Re-enables login after a certain amount of time (see :unlock_in below)
  * 'both'  = Enables both strategies
  * 'none'  = No unlock strategy. You should handle unlocking by yourself.

`MAXIMUM_ATTEMPTS: 5 by default`
 Number of authentication tries before locking an account if lock_strategy is failed attempts.

`UNLOCK_INTERVAL (in seconds) 3600 by default`
 Time interval to unlock the account if 'time' or 'both' is enabled as unlock_strategy.

`LAST_ATTEMPT_WARNING: ['true', 'false']`
 Warn on the last attempt before the account is locked.