### PR TITLE
Added ability to define levels by env variable

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -48,9 +48,9 @@ class Account < ApplicationRecord
                  .map { |l| [l.key, l.value].join ':' }
     levels = Level.all.order(id: :asc)
 
-    levels.each do |lvl|
+    levels.each_with_index do |lvl, index|
       break unless tags.include?(lvl.key + ':' + lvl.value)
-      account_level = lvl.id
+      account_level = index + 1
     end
 
     update(level: account_level)

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -2,7 +2,7 @@
 
 # Label level mapping model
 class Level < ApplicationRecord
-  validates :key, :value, :description, presence: true
+  validates :key, :value, presence: true
   validates :value, uniqueness: { scope: :key }
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,12 +82,23 @@ seeds['applications'].each do |seed|
   result[:applications].push(app.as_json(only: %i[name redirect_uri uid secret]))
 end
 
+# Example env: 'phone:verified,email:verifed,document:verified,identity:verified'
 logger.info '---'
 logger.info 'Seeding levels'
-seeds['levels'].each do |level_data|
-  next if Level.exists?(level_data)
-  Level.create!(level_data)
+levels = ENV['LEVELS']
+if levels.nil?
+  seeds['levels'].each do |level_data|
+    next if Level.exists?(level_data)
+    Level.create!(level_data)
+  end
+else
+  levels = levels.split(',')
+  levels.each do |level|
+    level_data = level.split(':')
+    Level.create(key: level_data[0], value: level_data[1])
+  end
 end
+
 
 # print well-formated json to stderr (easy to read in the commant output)
 logger.info "Result:\n#{JSON.pretty_generate(result)}"

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -5,5 +5,4 @@ require 'spec_helper'
 RSpec.describe Level, type: :model do
   it { should validate_presence_of(:key) }
   it { should validate_presence_of(:value) }
-  it { should validate_presence_of(:description) }
 end


### PR DESCRIPTION
Changed level setting way in account model from level id to level order index to be able to redefine levels.
Removed description from mandatory fields for easier level definition in ENV.
