### PR TITLE
Fixes docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN chown -R app:app $APP_HOME
 
 USER app
 
-RUN bundle exec rake tmp:create yarn:install assets:precompile
+# Initialize application configuration & assets.
+RUN ./bin/init_config \
+    && bundle exec rake tmp:create yarn:install assets:precompile
 
 # Expose port 8080 to the Docker host, so we can access it
 # from the outside.


### PR DESCRIPTION
I can't build barong docker image because of commit ee749a63ad8328a6bde56a079619c42dc75265ff
I think he forgot to run `init_config` in Dockerfile.